### PR TITLE
:sparkles: Improved notification handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
+[![GitHub release](https://img.shields.io/github/v/release/obecker/brew-auto-update-spoon?logo=github)](https://github.com/obecker/brew-auto-update-spoon/releases)
+
 # BrewAutoUpdate.spoon
 [Hammerspoon](https://www.hammerspoon.org) plugin (a.k.a. [Spoon](https://www.hammerspoon.org/go/#spoonsintro)) 
 for running `brew update` automatically.
 
-The plugin executes `brew update` at startup and then repeatedly every day (or some other defined interval).
+The plugin executes `brew update` at Hammerspoon's startup and then repeatedly every day (or some other defined interval).
 If there are outdated packages (determined by executing `brew outdated`) it will display a notification with a button
 to run `brew upgrade` in a Terminal.
 
 ![Example notification](images/notification.png)
 
+In case there are too many outdated packages that cannot be fully displayed within the limited space of the 
+notification's contents area, then clicking this contents area will toggle an alert with the full information.
+
 ## Installation
 
 _Prerequisite_: you have [Hammerspoon](https://www.hammerspoon.org) installed.
 
-Download [BrewAutoUpdate.spoon.zip](https://github.com/obecker/brew-auto-update-spoon/releases/download/v1.0.0/BrewAutoUpdate.spoon.zip) and double-click the extracted `BrewAutoUpdate.spoon` folder. 
+Download the latest **BrewAutoUpdate.spoon.zip** file from the [Releases](https://github.com/obecker/brew-auto-update-spoon/releases) 
+page and double-click the extracted `BrewAutoUpdate.spoon` folder. 
 Hammerspoon should automatically move it into your `$HOME/.hammerspoon/Spoons/` folder.
 
 Add this line to your `$HOME/.hammerspoon/init.lua` file:
@@ -20,11 +26,13 @@ Add this line to your `$HOME/.hammerspoon/init.lua` file:
 hs.loadSpoon("BrewAutoUpdate"):start()
 ```
 
-The plugin will auto-detect your `brew` binary and uses by default an update interval of 24 hours.
+The plugin will auto-detect your `brew` binary and uses by default an update interval of 24 hours and a duration of 
+5 seconds for displaying the additional information alert.
 You may overwrite these settings with
 ```lua
-hs.loadSpoon("BrewAutoUpdate")
-spoon.BrewAutoUpdate.brewBinary = "/path/to/your/brew"
-spoon.BrewAutoUpdate.updateInterval = "6h" -- run every 6 hours
-spoon.BrewAutoUpdate:start()
+local brewAutoUpdate = hs.loadSpoon("BrewAutoUpdate")
+brewAutoUpdate.brewBinary = "/path/to/your/brew"
+brewAutoUpdate.updateInterval = "6h" -- check for updates every 6 hours
+brewAutoUpdate.alertSeconds = 3 -- close the info alert after 3 seconds
+brewAutoUpdate:start()
 ```


### PR DESCRIPTION
- The plugin checks if there is already an active notification, and then it will keep it, close it, or replace it (depending on the new situation)
- Clicking the notification's contents area will toggle an information alert with the full notification contents (helpful, if this contents cannot be fully displayed in the limited space of the notification)